### PR TITLE
remove detectron2 & timm dependencies

### DIFF
--- a/modeling/backbone/backbone.py
+++ b/modeling/backbone/backbone.py
@@ -1,11 +1,22 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from abc import ABCMeta, abstractmethod
-from typing import Dict
+from typing import Dict, Optional
 import torch.nn as nn
 
-from detectron2.layers import ShapeSpec
-
 __all__ = ["Backbone"]
+
+
+class ShapeSpec:
+    """
+    A simple structure that contains basic shape specification about a tensor.
+    It is often used as the auxiliary inputs/outputs of models,
+    to complement the lack of shape inference ability among pytorch modules.
+    """
+
+    channels: Optional[int] = None
+    height: Optional[int] = None
+    width: Optional[int] = None
+    stride: Optional[int] = None
 
 
 class Backbone(nn.Module, metaclass=ABCMeta):

--- a/modeling/decoder/detail_capture.py
+++ b/modeling/decoder/detail_capture.py
@@ -131,10 +131,13 @@ class Detail_Capture(nn.Module):
 
     def forward(self, features, images):
         detail_features = self.convstream(images)
-        for i, fusion_block in enumerate(self.fusion_blks):
-            d_name_ = 'D'+str(len(self.fusion_blks)-i-1)
-            features = fusion_block(features, detail_features[d_name_])
-        
+
+        # unrolled loop
+        features = self.fusion_blks[0](features, detail_features["D3"])
+        features = self.fusion_blks[1](features, detail_features["D2"])
+        features = self.fusion_blks[2](features, detail_features["D1"])
+        features = self.fusion_blks[3](features, detail_features["D0"])
+
         phas = torch.sigmoid(self.matting_head(features))
 
         return {'phas': phas}

--- a/modeling/meta_arch/vitmatte.py
+++ b/modeling/meta_arch/vitmatte.py
@@ -2,10 +2,7 @@ from typing import Dict
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torchvision
-import os
 
-from detectron2.structures import ImageList
 
 class ViTMatte(nn.Module):
     def __init__(self,
@@ -52,9 +49,10 @@ class ViTMatte(nn.Module):
         """
         Normalize, pad and batch the input images.
         """
-        images = batched_inputs["image"].to(self.device)
-        trimap = batched_inputs['trimap'].to(self.device)
+        images = batched_inputs["image"]
+        trimap = batched_inputs['trimap']
         images = (images - self.pixel_mean) / self.pixel_std
+        device = images.device
 
         if 'fg' in batched_inputs.keys():
             trimap[trimap < 85] = 0
@@ -67,12 +65,12 @@ class ViTMatte(nn.Module):
         if images.shape[-1]%32!=0 or images.shape[-2]%32!=0:
             new_H = (32-images.shape[-2]%32) + H
             new_W = (32-images.shape[-1]%32) + W
-            new_images = torch.zeros((images.shape[0], images.shape[1], new_H, new_W)).to(self.device)
+            new_images = torch.zeros((images.shape[0], images.shape[1], new_H, new_W)).to(device)
             new_images[:,:,:H,:W] = images[:,:,:,:]
             images = new_images
 
         if "alpha" in batched_inputs:
-            phas = batched_inputs["alpha"].to(self.device)
+            phas = batched_inputs["alpha"].to(device)
         else:
             phas = None
 

--- a/nuke_vitmatte.py
+++ b/nuke_vitmatte.py
@@ -1,7 +1,6 @@
 import logging
 
 import torch
-from detectron2.checkpoint import DetectionCheckpointer
 from torch import nn
 
 from modeling import Detail_Capture, ViT, ViTMatte
@@ -77,7 +76,8 @@ if __name__ == "__main__":
     # Load the ViTMatte model
     vitmatte.to(device)
     vitmatte.eval()
-    DetectionCheckpointer(vitmatte).load(VITMATTE_MODEL)
+    checkpoint = torch.load(VITMATTE_MODEL, map_location=torch.device("cpu"))
+    vitmatte.load_state_dict(checkpoint, strict=False)
 
     # Convert the ViTMatte model to a TorchScript model
     vitmatte_nuke = VitMatteNuke(vitmatte)


### PR DESCRIPTION
This change enables compilation with vanilla PyTorch.
It also ensures compatibility with PyTorch 1.6 (used in Nuke 13).